### PR TITLE
Fixes for rules_nodejs v0.32.1

### DIFF
--- a/internal/closure.bzl
+++ b/internal/closure.bzl
@@ -3,7 +3,8 @@ load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeMod
 # load("@build_bazel_rules_typescript//internal:common/compilation.bzl", "COMMON_ATTRIBUTES", "DEPS_ASPECTS", "compile_ts", "ts_providers_dict_to_struct")
 # load("@build_bazel_rules_typescript//internal:common/tsconfig.bzl", "create_tsconfig")
 load("@npm_bazel_typescript//internal:ts_config.bzl", "TsConfigInfo")
-load("@npm_bazel_typescript//internal:build_defs.bzl", "COMMON_ATTRIBUTES", "DEPS_ASPECTS", "compile_ts", "ts_providers_dict_to_struct", "tsc_wrapped_tsconfig")
+load("@npm_bazel_typescript//internal:common/compilation.bzl", "COMMON_ATTRIBUTES", "DEPS_ASPECTS", "compile_ts", "ts_providers_dict_to_struct")
+load("@npm_bazel_typescript//internal:build_defs.bzl", "tsc_wrapped_tsconfig")
 load("@io_bazel_rules_closure//closure:defs.bzl", "CLOSURE_JS_TOOLCHAIN_ATTRS", "create_closure_js_library")
 
 # TODO: share code with @npm_bazel_typescript//internal:build_defs.bzl.


### PR DESCRIPTION
This changeset applies a fix to be able to use `rules_ts_closure` against the [latest release](https://github.com/bazelbuild/rules_nodejs/releases/tag/0.32.1) of `rules_nodejs`.